### PR TITLE
Finalize index page 

### DIFF
--- a/client/src/components/CourseSearchBar.tsx
+++ b/client/src/components/CourseSearchBar.tsx
@@ -11,8 +11,9 @@ export const CourseSearchBar = ({
   results,
   handleInputChange,
 }: CourseSearchBarProps) => {
-  const [searchSelected, setSearchSelected] = useState(false);
   const parser = new DOMParser();
+
+  const [searchSelected, setSearchSelected] = useState(false);
 
   return (
     <div className='relative'>
@@ -29,7 +30,7 @@ export const CourseSearchBar = ({
         </div>
         <input
           type='text'
-          className='outline-none border-none bg-neutral-50 border border-neutral-50 text-black text-sm rounded-lg block w-full pl-10 p-2.5 dark:bg-neutral-50 dark:border-neutral-50 dark:placeholder-neutral-500 dark:text-black'
+          className='outline-none border-none bg-neutral-50 border border-neutral-50 text-black text-sm rounded-lg block w-full pl-10 p-3 dark:bg-neutral-50 dark:border-neutral-50 dark:placeholder-neutral-500 dark:text-black'
           placeholder='Search for courses, subjects or professors'
           onChange={(event) => handleInputChange(event.target.value)}
           onFocus={() => setSearchSelected(true)}
@@ -41,7 +42,7 @@ export const CourseSearchBar = ({
           {results.map((result, index) => (
             <a href={`/course/${result._id}`}>
               <div
-                className={`p-2 hover:bg-gray-100 cursor-pointer text-left ${
+                className={`p-3 hover:bg-gray-100 cursor-pointer text-left ${
                   index < results.length - 1 && 'border-b border-gray-200'
                 }`}
                 key={result._id}

--- a/client/src/components/CourseSearchBar.tsx
+++ b/client/src/components/CourseSearchBar.tsx
@@ -39,7 +39,7 @@ export const CourseSearchBar = ({
       {searchSelected && (
         <div className='absolute top-full w-full bg-white rounded-b-lg shadow-md overflow-hidden z-10'>
           {results.map((result, index) => (
-            <a href={`/courses/${result._id}`} >
+            <a href={`/course/${result._id}`} >
               <div
                 className={`p-2 hover:bg-gray-100 cursor-pointer text-left ${
                   index < results.length - 1 && 'border-b border-gray-200'

--- a/client/src/components/CourseSearchBar.tsx
+++ b/client/src/components/CourseSearchBar.tsx
@@ -39,14 +39,18 @@ export const CourseSearchBar = ({
       {searchSelected && (
         <div className='absolute top-full w-full bg-white rounded-b-lg shadow-md overflow-hidden z-10'>
           {results.map((result, index) => (
-            <a href={`/course/${result._id}`} >
+            <a href={`/course/${result._id}`}>
               <div
                 className={`p-2 hover:bg-gray-100 cursor-pointer text-left ${
                   index < results.length - 1 && 'border-b border-gray-200'
                 }`}
                 key={result._id}
               >
-                {result._id} - {parser.parseFromString(result.title, 'text/html').body.textContent}
+                {result._id} -{' '}
+                {
+                  parser.parseFromString(result.title, 'text/html').body
+                    .textContent
+                }
               </div>
             </a>
           ))}

--- a/client/src/components/CourseSearchBar.tsx
+++ b/client/src/components/CourseSearchBar.tsx
@@ -12,6 +12,7 @@ export const CourseSearchBar = ({
   handleInputChange,
 }: CourseSearchBarProps) => {
   const [searchSelected, setSearchSelected] = useState(false);
+  const parser = new DOMParser();
 
   return (
     <div className='relative'>
@@ -38,14 +39,16 @@ export const CourseSearchBar = ({
       {searchSelected && (
         <div className='absolute top-full w-full bg-white rounded-b-lg shadow-md overflow-hidden z-10'>
           {results.map((result, index) => (
-            <div
-              className={`p-2 hover:bg-gray-100 cursor-pointer ${
-                index < results.length - 1 && 'border-b border-gray-200'
-              }`}
-              key={result._id}
-            >
-              {result._id} - {result.title}
-            </div>
+            <a href={`/courses/${result._id}`} >
+              <div
+                className={`p-2 hover:bg-gray-100 cursor-pointer text-left ${
+                  index < results.length - 1 && 'border-b border-gray-200'
+                }`}
+                key={result._id}
+              >
+                {result._id} - {parser.parseFromString(result.title, 'text/html').body.textContent}
+              </div>
+            </a>
           ))}
         </div>
       )}

--- a/client/src/components/CourseSearchBar.tsx
+++ b/client/src/components/CourseSearchBar.tsx
@@ -32,7 +32,7 @@ export const CourseSearchBar = ({
           placeholder='Search for courses, subjects or professors'
           onChange={(event) => handleInputChange(event.target.value)}
           onFocus={() => setSearchSelected(true)}
-          onBlur={() => setSearchSelected(false)}
+          onBlur={() => setTimeout(() => setSearchSelected(false), 200)}
         />
       </div>
       {searchSelected && (

--- a/client/src/components/CourseSearchBar.tsx
+++ b/client/src/components/CourseSearchBar.tsx
@@ -19,7 +19,7 @@ export const CourseSearchBar = ({
       <div className='relative w-full mt-4'>
         <div className='absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none'>
           <Search
-            size={19}
+            size={20}
             className={
               'transition duration-200 ' +
               (searchSelected ? 'stroke-red-600' : 'stroke-gray-400')

--- a/client/src/components/CourseSearchBar.tsx
+++ b/client/src/components/CourseSearchBar.tsx
@@ -19,7 +19,7 @@ export const CourseSearchBar = ({
       <div className='relative w-full mt-4'>
         <div className='absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none'>
           <Search
-            size={20}
+            size={19}
             className={
               'transition duration-200 ' +
               (searchSelected ? 'stroke-red-600' : 'stroke-gray-400')

--- a/client/src/components/CourseSearchBar.tsx
+++ b/client/src/components/CourseSearchBar.tsx
@@ -33,7 +33,7 @@ export const CourseSearchBar = ({
           placeholder='Search for courses, subjects or professors'
           onChange={(event) => handleInputChange(event.target.value)}
           onFocus={() => setSearchSelected(true)}
-          onBlur={() => setTimeout(() => setSearchSelected(false), 200)}
+          onBlur={() => setTimeout(() => setSearchSelected(false), 80)}
         />
       </div>
       {searchSelected && (

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -5,10 +5,7 @@ import { useAuth } from '../hooks/useAuth';
 import { SideNav } from './SideNav';
 
 export const navigation = [
-  { name: 'Product', href: '#' },
-  { name: 'Features', href: '#' },
-  { name: 'Marketplace', href: '#' },
-  { name: 'Company', href: '#' },
+  { name: 'About', href: '/about' },
 ];
 
 export const Navbar = () => {

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -4,9 +4,7 @@ import { useState } from 'react';
 import { useAuth } from '../hooks/useAuth';
 import { SideNav } from './SideNav';
 
-export const navigation = [
-  { name: 'About', href: '/about' },
-];
+export const navigation = [{ name: 'About', href: '/about' }];
 
 export const Navbar = () => {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -15,7 +15,7 @@ export const Home = () => {
 
   const handleInputChange = async (query: string) => {
     try {
-      setResults((await fetchClient.getData<Course[]>(`/search?query=${query}`)));
+      setResults(await fetchClient.getData<Course[]>(`/search?query=${query}`));
     } catch (err) {
       console.error(err);
     }

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -15,7 +15,7 @@ export const Home = () => {
 
   const handleInputChange = async (query: string) => {
     try {
-      setResults(await fetchClient.getData<Course[]>(`/search?query=${query}`));
+      setResults((await fetchClient.getData<Course[]>(`/search?query=${query}`)).slice(0, 6));
     } catch (err) {
       console.error(err);
     }

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -15,7 +15,7 @@ export const Home = () => {
 
   const handleInputChange = async (query: string) => {
     try {
-      setResults((await fetchClient.getData<Course[]>(`/search?query=${query}`)).slice(0, 6));
+      setResults((await fetchClient.getData<Course[]>(`/search?query=${query}`)));
     } catch (err) {
       console.error(err);
     }


### PR DESCRIPTION
Index page is pretty much done. 

Changes:
- Made magnifying glass icon slightly smaller
- Added a parser to parse `&amp;` in course titles
- Added links to each search result suggestion in the format of `/cource/${result._id}`
- Removed the nav bar buttons from the template and added a button for About page
- Capped the search results' array size to 6 to avoid overflowing the screen 

<img width="1269" alt="Screenshot 2023-03-25 at 2 40 08 PM" src="https://user-images.githubusercontent.com/112342947/227735526-ab5c3ad1-d0ba-4e20-bd33-cb21ab120c9e.png">
