### PR TITLE
Add keybinding for search bar results

### DIFF
--- a/client/src/components/CourseSearchBar.tsx
+++ b/client/src/components/CourseSearchBar.tsx
@@ -17,6 +17,22 @@ export const CourseSearchBar = ({
   const parser = new DOMParser();
 
   const [searchSelected, setSearchSelected] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(-1);
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      setSelectedIndex((prevIndex) => (prevIndex > 0 ? prevIndex - 1 : -1));
+    } else if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      setSelectedIndex((prevIndex) =>
+        prevIndex < results.length - 1 ? prevIndex + 1 : results.length - 1
+      );
+    }
+    if (selectedIndex > -1 && event.key === 'Enter') {
+      window.location.href = `/course/${results[selectedIndex]._id}`;
+    }
+  };
 
   return (
     <div className='relative'>
@@ -38,6 +54,7 @@ export const CourseSearchBar = ({
           onChange={(event) => handleInputChange(event.target.value)}
           onFocus={() => setSearchSelected(true)}
           onBlur={() => setTimeout(() => setSearchSelected(false), 80)}
+          onKeyDown={handleKeyDown} // new event handler for arrow keys
         />
       </div>
       {searchSelected && (
@@ -45,7 +62,10 @@ export const CourseSearchBar = ({
           {results.map((result, index) => (
             <Link to={`/course/${result._id}`}>
               <div
-                className='p-3 hover:bg-gray-100 cursor-pointer text-left border-b border-gray-200'
+                className={classNames(
+                  'p-3 hover:bg-gray-100 cursor-pointer text-left border-b border-gray-200',
+                  selectedIndex === index && 'bg-gray-100'
+                )}
                 key={result._id}
               >
                 {result._id} -{' '}

--- a/client/src/components/CourseSearchBar.tsx
+++ b/client/src/components/CourseSearchBar.tsx
@@ -55,7 +55,7 @@ export const CourseSearchBar = ({
           onChange={(event) => handleInputChange(event.target.value)}
           onFocus={() => setSearchSelected(true)}
           onBlur={() => setTimeout(() => setSearchSelected(false), 80)}
-          onKeyDown={handleKeyDown} 
+          onKeyDown={handleKeyDown}
         />
       </div>
       {searchSelected && (
@@ -65,7 +65,7 @@ export const CourseSearchBar = ({
               <div
                 className={classNames(
                   'p-3 hover:bg-gray-100 cursor-pointer text-left border-b border-gray-200',
-                  selectedIndex === index && 'bg-gray-100'
+                  selectedIndex === index ? 'bg-gray-100' : ''
                 )}
                 key={result._id}
               >

--- a/client/src/components/CourseSearchBar.tsx
+++ b/client/src/components/CourseSearchBar.tsx
@@ -55,7 +55,7 @@ export const CourseSearchBar = ({
           onChange={(event) => handleInputChange(event.target.value)}
           onFocus={() => setSearchSelected(true)}
           onBlur={() => setTimeout(() => setSearchSelected(false), 80)}
-          onKeyDown={handleKeyDown} // new event handler for arrow keys
+          onKeyDown={handleKeyDown} 
         />
       </div>
       {searchSelected && (

--- a/client/src/components/CourseSearchBar.tsx
+++ b/client/src/components/CourseSearchBar.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Layers, Search } from 'react-feather';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 
 import { classNames } from '../lib/classNames';
 import { Course } from '../model/course';
@@ -15,6 +15,7 @@ export const CourseSearchBar = ({
   handleInputChange,
 }: CourseSearchBarProps) => {
   const parser = new DOMParser();
+  const navigate = useNavigate();
 
   const [searchSelected, setSearchSelected] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(-1);
@@ -30,7 +31,7 @@ export const CourseSearchBar = ({
       );
     }
     if (selectedIndex > -1 && event.key === 'Enter') {
-      window.location.href = `/course/${results[selectedIndex]._id}`;
+      navigate(`/course/${results[selectedIndex]._id}`);
     }
   };
 


### PR DESCRIPTION
I added arrow-key navigation for the search bar results.
It currently navigates through every search result, but not the `explore all courses` rectangle.

Let me know if you like it as is or you prefer the `explore all courses` rectangle to be included as well.