### PR TITLE
CourseTerm tag for non-offered courses

### DIFF
--- a/client/src/components/CourseInfo.tsx
+++ b/client/src/components/CourseInfo.tsx
@@ -29,11 +29,7 @@ export const CourseInfo = ({ course }: { course: Course }) => {
             <h2 className='text-3xl text-gray-800 dark:text-gray-200'>
               {course.title}
             </h2>
-            {course.terms.length > 0 ? (
-              <CourseTerms course={course} variant='large' />
-            ) : (
-              <p>This course is not currently being offered.</p>
-            )}
+            <CourseTerms course={course} variant='large' />
             <p className='break-words text-gray-500 dark:text-gray-400'>
               {course.description}
             </p>

--- a/client/src/components/CourseTerms.tsx
+++ b/client/src/components/CourseTerms.tsx
@@ -29,14 +29,13 @@ type CourseTermsProps = {
 
 export const CourseTerms = ({ course, variant }: CourseTermsProps) => {
   const instructors = uniqueTermInstructors(course);
+  const container = classNames(
+    'flex',
+    variant === 'small' ? 'space-x-2' : 'space-x-3'
+  );
 
   return instructors.length !== 0 ? (
-    <div
-      className={classNames(
-        'flex',
-        variant === 'small' ? 'space-x-2' : 'space-x-3'
-      )}
-    >
+    <div className={container}>
       {instructors.map((instructor, i) => (
         <div
           key={i}
@@ -53,12 +52,7 @@ export const CourseTerms = ({ course, variant }: CourseTermsProps) => {
       ))}
     </div>
   ) : (
-    <div
-      className={classNames(
-        'flex',
-        variant === 'small' ? 'space-x-2' : 'space-x-3'
-      )}
-    >
+    <div className={container}>
       <div
         className={classNames(
           'rounded-xl bg-gray-100 dark:bg-neutral-700',

--- a/client/src/components/CourseTerms.tsx
+++ b/client/src/components/CourseTerms.tsx
@@ -3,10 +3,15 @@ import { FaLeaf, FaRegSnowflake } from 'react-icons/fa';
 
 import { classNames, uniqueTermInstructors } from '../lib/utils';
 import { Course } from '../model/Course';
+import { GoX } from 'react-icons/go';
+
+const variantToSize = (variant: 'small' | 'large') => {
+  return variant === 'small' ? 20 : 25;
+};
 
 const termToIcon = (term: string, variant: 'small' | 'large') => {
   type IconMap = { [key: string]: JSX.Element };
-  const size = variant === 'small' ? 20 : 25;
+  const size = variantToSize(variant);
 
   const icons: IconMap = {
     fall: <FaLeaf size={size} color='Brown' />,
@@ -47,5 +52,24 @@ export const CourseTerms = ({ course, variant }: CourseTermsProps) => {
         </div>
       ))}
     </div>
-  ) : null;
+  ) : (
+    <div
+      className={classNames(
+        'flex',
+        variant === 'small' ? 'space-x-2' : 'space-x-3'
+      )}
+    >
+      <div
+        className={classNames(
+          'rounded-xl bg-gray-100 dark:bg-neutral-700',
+          variant === 'small' ? 'py-1 px-2' : 'p-2'
+        )}
+      >
+        <div className='flex items-center space-x-2'>
+          <GoX size={variantToSize(variant)} color='DarkGray' />
+          <div className='pr-1 dark:text-gray-200'>Not Offered</div>
+        </div>
+      </div>
+    </div>
+  );
 };


### PR DESCRIPTION
Added a CourseTerm tag for non-offered courses. 
Displayed in explore page and course page. 

<img width="590" alt="Screenshot 2023-04-30 at 8 01 31 PM" src="https://user-images.githubusercontent.com/112342947/235351824-754fb979-6af6-4778-9c5b-1f881fcb70a8.png">
